### PR TITLE
Add subtype STM32U5G9 to STM32U5 family

### DIFF
--- a/Middlewares/Third_Party/pal/targets/TARGET_STM32/Inc/stm32_cyhal_common.h
+++ b/Middlewares/Third_Party/pal/targets/TARGET_STM32/Inc/stm32_cyhal_common.h
@@ -53,7 +53,8 @@
     defined (STM32U595xx)   || \
     defined (STM32U599xx)   || \
     defined (STM32U5A5xx)   || \
-    defined (STM32U5A9xx)
+    defined (STM32U5A9xx)   || \
+    defined (STM32U5G9xx)
     #define TARGET_STM32U5xx
 #elif defined (STM32H563xx)
     #define TARGET_STM32H5xx


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
With this commit also the STM32U5G9 is working.